### PR TITLE
Add Eigen3::Eigen link to WBToolboxBase target

### DIFF
--- a/toolbox/base/CMakeLists.txt
+++ b/toolbox/base/CMakeLists.txt
@@ -25,7 +25,8 @@ target_link_libraries(WBToolboxBase
     YARP::YARP_dev
     iDynTree::idyntree-model
     iDynTree::idyntree-modelio
-    iDynTree::idyntree-high-level)
+    iDynTree::idyntree-high-level
+    Eigen3::Eigen)
 
 target_include_directories(WBToolboxBase PUBLIC
     $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>


### PR DESCRIPTION
I have no idea how this worked before, but indeed `Eigen/Core` header is used in WBToolboxBase, so we need to link the `Eigen3::Eigen` target. Somehow this used to work in some way, but it stopped working with Eigen3 5.0.0.


xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47